### PR TITLE
Add Woo Special Product Offer plugin scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# woo-special-product-offer
+# Woo Special Product Offer
+
+**Version:** 1.0.0  \
+**Author:** [Wan Mohd Aiman Binawebpro.com]
+
+Woo Special Product Offer is a lightweight WordPress plugin that enriches WooCommerce product pages with a modern “Purchase Options” experience. Customers can easily toggle between one-time purchases and subscriptions, choose their preferred delivery frequency, and instantly understand how much they will save. Behind the scenes the plugin keeps the cart, checkout, and resulting orders in sync with each shopper’s selection.
+
+## Highlights
+
+- Streamlined purchase selector injected directly into WooCommerce single product forms.
+- Customisable discount engine for subscription purchases with flexible frequency options.
+- Cart, checkout, and order meta automatically display the customer’s choices.
+- Admin controls tucked neatly under **WooCommerce → Special Offer**.
+- Crafted with clean, modern code that stays out of the way of your storefront styling.
+
+## Requirements
+
+- WordPress 6.0 or newer
+- WooCommerce 7.0 or newer
+- PHP 7.4+
+
+## Installation
+
+1. Copy the plugin directory into your WooCommerce project at `wp-content/plugins/woo-special-product-offer/`.
+2. Log into your WordPress admin dashboard and navigate to **Plugins → Installed Plugins**.
+3. Activate **Woo Special Product Offer**.
+4. During activation the plugin seeds sensible defaults (subscription enabled, 10% discount, weekly/monthly frequencies).
+
+## Configuration
+
+After activation visit **WooCommerce → Special Offer** to tailor the behaviour:
+
+- **Enable subscription offers** – toggle availability of the subscription option on product pages.
+- **Subscription discount (%)** – percentage discount applied to subscription purchases. The value is clamped between 0 and 100 and drives the automatic price adjustments in the cart.
+- **Subscription frequencies** – define one frequency label per line (for example “Every Week”). Each label becomes an option in the product page dropdown and is saved with cart items and orders.
+
+All settings are stored as a single option (`wspo_settings`) making backup and deployment straightforward. Changes take effect immediately on the storefront.
+
+## Frontend behaviour
+
+- The plugin enqueues a minimal CSS/JS bundle only on single-product pages (`is_product()`).
+- The “Purchase Options” panel is injected before the default add-to-cart button using WooCommerce hooks.
+- JavaScript enhances the UI with card highlighting, progressive disclosure of the frequency select box, and contextual messaging about discounts.
+- The PHP template lives at `templates/purchase-options.php`. Developers can override the heading/helper text through the `wspo_purchase_options_heading` and `wspo_purchase_options_helper_text` filters.
+
+## Pricing and persistence
+
+- Customer selections are sanitised and stored inside cart item data with a base price snapshot.
+- Subscription items receive the configured percentage discount during `woocommerce_before_calculate_totals` and whenever carts are restored from the session.
+- Cart, checkout, and order summaries automatically surface the purchase type, chosen frequency, and savings so both the shopper and fulfilment teams stay informed.
+
+## Usage tips
+
+- Pair the plugin with WooCommerce Subscriptions or a custom recurring billing flow to complete the subscription experience.
+- To completely disable subscriptions simply uncheck the setting—customers will only see the one-time purchase option while the UI stays consistent.
+- Use WordPress translation tools (e.g. [Loco Translate](https://wordpress.org/plugins/loco-translate/)) to localise the text strings bundled with the plugin.
+
+## Development
+
+The codebase follows WordPress best practices with namespaced-style class prefixes (`WSPO_`). Assets are versioned alongside the plugin (`WSPO_VERSION`) for proper cache-busting. Feel free to extend behaviour via WordPress hooks or by copying the provided template into your theme and customising it with the standard WooCommerce template hierarchy.
+
+If you improve or redistribute the plugin, please retain attribution to **[Wan Mohd Aiman Binawebpro.com]**.

--- a/wp-content/plugins/woo-special-product-offer/assets/css/woo-special-product-offer.css
+++ b/wp-content/plugins/woo-special-product-offer/assets/css/woo-special-product-offer.css
@@ -1,0 +1,140 @@
+.wspo-purchase-options {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 1.5rem;
+    margin: 2rem 0;
+    background-color: #ffffff;
+    box-shadow: 0 10px 30px -20px rgba(15, 23, 42, 0.45);
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.wspo-purchase-options:hover {
+    border-color: #cbd5f5;
+    box-shadow: 0 22px 45px -25px rgba(79, 70, 229, 0.35);
+}
+
+.wspo-header {
+    margin-bottom: 1.5rem;
+}
+
+.wspo-title {
+    margin: 0 0 0.25rem;
+    font-size: 1.35rem;
+    font-weight: 600;
+}
+
+.wspo-helper {
+    margin: 0;
+    color: #4a5568;
+    font-size: 0.95rem;
+}
+
+.wspo-option {
+    border-top: 1px solid #edf2f7;
+    padding-top: 1rem;
+    margin-top: 1rem;
+}
+
+.wspo-option:first-of-type {
+    border-top: none;
+    padding-top: 0;
+    margin-top: 0;
+}
+
+.wspo-option-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+    border-radius: 10px;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.wspo-option-card:hover {
+    background-color: rgba(79, 70, 229, 0.08);
+}
+
+.wspo-option-card.is-active {
+    background-color: rgba(79, 70, 229, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.25);
+}
+
+.wspo-option-card input[type='radio'] {
+    margin-top: 0.35rem;
+}
+
+.wspo-option-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.wspo-option-title {
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.wspo-option-description {
+    color: #4a5568;
+    font-size: 0.92rem;
+}
+
+.wspo-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2rem 0.6rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    color: #ffffff;
+}
+
+.wspo-frequency {
+    margin: 0.75rem 0 0 2.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.wspo-frequency label {
+    font-weight: 500;
+}
+
+.wspo-frequency select {
+    max-width: 220px;
+}
+
+.wspo-hidden {
+    display: none !important;
+}
+
+.wspo-price-note {
+    margin: 0 0 1.25rem;
+    font-weight: 500;
+    color: #4338ca;
+    display: none;
+}
+
+.wspo-price-note.is-visible {
+    display: block;
+}
+
+@media (max-width: 600px) {
+    .wspo-purchase-options {
+        padding: 1.25rem;
+    }
+
+    .wspo-option-card {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .wspo-frequency {
+        margin-left: 0;
+    }
+}

--- a/wp-content/plugins/woo-special-product-offer/assets/js/woo-special-product-offer.js
+++ b/wp-content/plugins/woo-special-product-offer/assets/js/woo-special-product-offer.js
@@ -1,0 +1,85 @@
+(function ($) {
+    'use strict';
+
+    var formatPercentage = function (value) {
+        var number = parseFloat(value);
+
+        if (isNaN(number)) {
+            return '';
+        }
+
+        if (Math.abs(number % 1) < 0.0001) {
+            return number.toFixed(0);
+        }
+
+        return number.toFixed(2).replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+    };
+
+    var ready = function () {
+        $('.wspo-purchase-options').each(function () {
+            var $container = $(this);
+            var $options = $container.find("input[name='wspo_purchase_type']");
+            var $frequency = $container.find('.wspo-frequency');
+            var $note = $container.find('.wspo-price-note');
+            var discount = parseFloat($container.data('discount')) || 0;
+            var strings = window.wspoPurchaseOptions && window.wspoPurchaseOptions.strings ? window.wspoPurchaseOptions.strings : {};
+
+            var getString = function (key) {
+                return strings && strings[key] ? strings[key] : '';
+            };
+
+            var updateNote = function (type) {
+                if (!$note.length) {
+                    return;
+                }
+
+                var message = '';
+
+                if (type === 'subscription') {
+                    if (discount > 0 && getString('subscriptionTemplate')) {
+                        message = getString('subscriptionTemplate').replace('%s', formatPercentage(discount));
+                    } else {
+                        message = getString('subscriptionNoDiscount');
+                    }
+                } else {
+                    message = getString('oneTime');
+                }
+
+                if (message) {
+                    $note.text(message).addClass('is-visible');
+                } else {
+                    $note.text('').removeClass('is-visible');
+                }
+            };
+
+            var toggleOptions = function () {
+                var $selected = $options.filter(':checked');
+                var type = $selected.length ? $selected.val() : 'one_time';
+                var showSubscription = type === 'subscription';
+
+                if ($frequency.length) {
+                    $frequency.toggleClass('wspo-hidden', !showSubscription);
+                }
+
+                $container.toggleClass('is-subscription', showSubscription);
+                $container.find('.wspo-option-card').removeClass('is-active');
+
+                if ($selected.length) {
+                    $selected.closest('.wspo-option-card').addClass('is-active');
+                }
+
+                updateNote(type);
+            };
+
+            $options.on('change', toggleOptions);
+
+            toggleOptions();
+        });
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', ready);
+    } else {
+        ready();
+    }
+})(jQuery);

--- a/wp-content/plugins/woo-special-product-offer/includes/class-wspo-frontend.php
+++ b/wp-content/plugins/woo-special-product-offer/includes/class-wspo-frontend.php
@@ -1,0 +1,327 @@
+<?php
+/**
+ * Frontend functionality for Woo Special Product Offer.
+ *
+ * @package Woo_Special_Product_Offer
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WSPO_Frontend' ) ) {
+
+    /**
+     * Handles public hooks and rendering.
+     */
+    class WSPO_Frontend {
+
+        /**
+         * Singleton instance.
+         *
+         * @var WSPO_Frontend|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Retrieve the frontend instance.
+         *
+         * @return WSPO_Frontend
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Hook into WordPress.
+         */
+        protected function __construct() {
+            add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+            add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'render_purchase_options' ), 15 );
+            add_filter( 'woocommerce_add_cart_item_data', array( $this, 'save_purchase_selection' ), 10, 3 );
+            add_filter( 'woocommerce_get_cart_item_from_session', array( $this, 'restore_cart_item_data' ), 10, 3 );
+            add_action( 'woocommerce_before_calculate_totals', array( $this, 'adjust_cart_item_price' ), 10 );
+            add_filter( 'woocommerce_get_item_data', array( $this, 'display_cart_item_data' ), 10, 2 );
+            add_action( 'woocommerce_checkout_create_order_line_item', array( $this, 'add_order_item_meta' ), 10, 4 );
+        }
+
+        /**
+         * Register scripts and styles.
+         */
+        public function enqueue_assets() {
+            if ( ! function_exists( 'is_product' ) || ! is_product() ) {
+                return;
+            }
+
+            wp_enqueue_style(
+                'wspo-frontend',
+                WSPO_PLUGIN_URL . 'assets/css/woo-special-product-offer.css',
+                array(),
+                WSPO_VERSION
+            );
+
+            wp_enqueue_script(
+                'wspo-frontend',
+                WSPO_PLUGIN_URL . 'assets/js/woo-special-product-offer.js',
+                array( 'jquery' ),
+                WSPO_VERSION,
+                true
+            );
+
+            $settings = WSPO_Plugin::get_settings();
+
+            wp_localize_script(
+                'wspo-frontend',
+                'wspoPurchaseOptions',
+                array(
+                    'discount' => isset( $settings['subscription_discount'] ) ? floatval( $settings['subscription_discount'] ) : 0,
+                    'strings'  => array(
+                        'subscriptionTemplate'    => __( 'Save %s%% on every delivery. Discount applied at checkout.', 'woo-special-product-offer' ),
+                        'subscriptionNoDiscount'  => __( 'Subscription selected. Pricing will update at checkout.', 'woo-special-product-offer' ),
+                        'oneTime'                 => __( 'One-time purchase selected.', 'woo-special-product-offer' ),
+                    ),
+                )
+            );
+        }
+
+        /**
+         * Render purchase options on the product page.
+         */
+        public function render_purchase_options() {
+            global $product;
+
+            if ( ! class_exists( 'WC_Product' ) ) {
+                return;
+            }
+
+            if ( ! $product instanceof WC_Product ) {
+                return;
+            }
+
+            $settings    = WSPO_Plugin::get_settings();
+            $frequencies = WSPO_Plugin::get_frequency_options();
+
+            if ( empty( $settings['enable_subscription'] ) && empty( $frequencies ) ) {
+                return;
+            }
+
+            WSPO_Plugin::get_template(
+                'purchase-options.php',
+                array(
+                    'product'      => $product,
+                    'settings'     => $settings,
+                    'frequencies'  => $frequencies,
+                    'has_subscribe' => ! empty( $settings['enable_subscription'] ) && ! empty( $frequencies ),
+                )
+            );
+        }
+
+        /**
+         * Persist purchase selections to the cart.
+         *
+         * @param array $cart_item_data Existing cart item data.
+         * @param int   $product_id     Product identifier.
+         * @param int   $variation_id   Variation identifier.
+         * @return array
+         */
+        public function save_purchase_selection( $cart_item_data, $product_id, $variation_id ) {
+            if ( ! function_exists( 'wc_get_product' ) ) {
+                return $cart_item_data;
+            }
+
+            $nonce = isset( $_POST['wspo_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wspo_nonce'] ) ) : '';
+
+            if ( $nonce && ! wp_verify_nonce( $nonce, 'wspo_purchase_options' ) ) {
+                return $cart_item_data;
+            }
+
+            $purchase_type = isset( $_POST['wspo_purchase_type'] ) ? sanitize_key( wp_unslash( $_POST['wspo_purchase_type'] ) ) : 'one_time';
+            $frequency     = isset( $_POST['wspo_plan_frequency'] ) ? sanitize_key( wp_unslash( $_POST['wspo_plan_frequency'] ) ) : '';
+
+            $valid_types = array( 'one_time', 'subscription' );
+            if ( ! in_array( $purchase_type, $valid_types, true ) ) {
+                $purchase_type = 'one_time';
+            }
+
+            $settings          = WSPO_Plugin::get_settings();
+            $frequency_options = WSPO_Plugin::get_frequency_options();
+
+            $frequency_label = '';
+
+            if ( 'subscription' === $purchase_type ) {
+                if ( empty( $frequency_options ) ) {
+                    $purchase_type = 'one_time';
+                    $frequency     = '';
+                } else {
+                    if ( empty( $frequency ) || ! array_key_exists( $frequency, $frequency_options ) ) {
+                        $frequency_keys = array_keys( $frequency_options );
+                        $frequency      = reset( $frequency_keys );
+                    }
+
+                    if ( $frequency && array_key_exists( $frequency, $frequency_options ) ) {
+                        $frequency_label = $frequency_options[ $frequency ];
+                    }
+                }
+            } else {
+                $frequency = '';
+            }
+
+            $product_object = $variation_id ? wc_get_product( $variation_id ) : wc_get_product( $product_id );
+            $base_price     = $product_object instanceof WC_Product ? max( 0, (float) $product_object->get_price() ) : 0;
+
+            $discount_value = isset( $settings['subscription_discount'] ) ? max( 0, min( 100, floatval( $settings['subscription_discount'] ) ) ) : 0;
+
+            $wspo_data = array(
+                'type'            => $purchase_type,
+                'frequency'       => $frequency,
+                'frequency_label' => $frequency_label,
+                'discount'        => $discount_value,
+                'base_price'      => $base_price,
+            );
+
+            $cart_item_data['wspo_data']    = $wspo_data;
+            $cart_item_data['wspo_cart_id'] = md5( wp_json_encode( $wspo_data ) );
+
+            return $cart_item_data;
+        }
+
+        /**
+         * Restore the purchase options when loading cart data from the session.
+         *
+         * @param array $cart_item Cart item array.
+         * @param array $values    Stored values.
+         * @param string $cart_item_key Cart item key.
+         * @return array
+         */
+        public function restore_cart_item_data( $cart_item, $values, $cart_item_key ) {
+            if ( isset( $values['wspo_data'] ) ) {
+                $cart_item['wspo_data'] = $values['wspo_data'];
+            }
+
+            if ( isset( $cart_item['wspo_data']['discount'] ) ) {
+                $cart_item['wspo_data']['discount'] = max( 0, min( 100, floatval( $cart_item['wspo_data']['discount'] ) ) );
+            }
+
+            if ( class_exists( 'WC_Product' ) && isset( $cart_item['wspo_data']['base_price'] ) && isset( $cart_item['data'] ) && $cart_item['data'] instanceof WC_Product ) {
+                $cart_item['wspo_data']['base_price'] = max( 0, (float) $cart_item['wspo_data']['base_price'] );
+            }
+
+            return $cart_item;
+        }
+
+        /**
+         * Adjust prices in the cart for subscriptions.
+         *
+         * @param WC_Cart $cart WooCommerce cart object.
+         */
+        public function adjust_cart_item_price( $cart ) {
+            if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
+                return;
+            }
+
+            if ( ! class_exists( 'WC_Cart' ) || ! $cart instanceof WC_Cart || empty( $cart->cart_contents ) ) {
+                return;
+            }
+
+            foreach ( $cart->get_cart() as $cart_item_key => $cart_item ) {
+                if ( empty( $cart_item['wspo_data'] ) || ! isset( $cart_item['data'] ) || ! class_exists( 'WC_Product' ) || ! $cart_item['data'] instanceof WC_Product ) {
+                    continue;
+                }
+
+                $data = $cart_item['wspo_data'];
+
+                if ( 'subscription' !== $data['type'] ) {
+                    continue;
+                }
+
+                $base_price = isset( $data['base_price'] ) ? (float) $data['base_price'] : $cart_item['data']->get_price();
+                $discount   = isset( $data['discount'] ) ? max( 0, min( 100, floatval( $data['discount'] ) ) ) : 0;
+                $adjusted   = $base_price * ( 1 - ( $discount / 100 ) );
+
+                if ( $adjusted < 0 ) {
+                    $adjusted = 0;
+                }
+
+                $cart->cart_contents[ $cart_item_key ]['data']->set_price( $adjusted );
+            }
+        }
+
+        /**
+         * Display purchase selections on cart and checkout screens.
+         *
+         * @param array $item_data Display data array.
+         * @param array $cart_item Cart item array.
+         * @return array
+         */
+        public function display_cart_item_data( $item_data, $cart_item ) {
+            if ( empty( $cart_item['wspo_data'] ) ) {
+                return $item_data;
+            }
+
+            $data       = $cart_item['wspo_data'];
+            $type_label = 'subscription' === $data['type'] ? __( 'Subscription', 'woo-special-product-offer' ) : __( 'One-time purchase', 'woo-special-product-offer' );
+
+            $item_data[] = array(
+                'name'  => __( 'Purchase Type', 'woo-special-product-offer' ),
+                'value' => $type_label,
+            );
+
+            if ( 'subscription' === $data['type'] && ! empty( $data['frequency_label'] ) ) {
+                $item_data[] = array(
+                    'name'  => __( 'Delivery Frequency', 'woo-special-product-offer' ),
+                    'value' => $data['frequency_label'],
+                );
+            }
+
+            if ( 'subscription' === $data['type'] && ! empty( $data['discount'] ) ) {
+                $discount_value = wc_format_decimal( floatval( $data['discount'] ), 2 );
+                $discount_value = rtrim( rtrim( $discount_value, '0' ), '.' );
+
+                $item_data[] = array(
+                    'name'  => __( 'Subscription Savings', 'woo-special-product-offer' ),
+                    'value' => sprintf( /* translators: %s: discount percentage. */ __( '%s%% discount', 'woo-special-product-offer' ), $discount_value ),
+                );
+            }
+
+            return $item_data;
+        }
+
+        /**
+         * Persist purchase selections to order line items.
+         *
+         * @param WC_Order_Item_Product $item          Order item instance.
+         * @param string                $cart_item_key Cart item key.
+         * @param array                 $values        Cart values.
+         * @param WC_Order              $order         Order instance.
+         */
+        public function add_order_item_meta( $item, $cart_item_key, $values, $order ) {
+            if ( empty( $values['wspo_data'] ) ) {
+                return;
+            }
+
+            $data       = $values['wspo_data'];
+            $type_label = 'subscription' === $data['type'] ? __( 'Subscription', 'woo-special-product-offer' ) : __( 'One-time purchase', 'woo-special-product-offer' );
+
+            $item->add_meta_data( __( 'Purchase Type', 'woo-special-product-offer' ), $type_label, true );
+
+            if ( 'subscription' === $data['type'] && ! empty( $data['frequency_label'] ) ) {
+                $item->add_meta_data( __( 'Delivery Frequency', 'woo-special-product-offer' ), $data['frequency_label'], true );
+            }
+
+            if ( 'subscription' === $data['type'] && ! empty( $data['discount'] ) ) {
+                $discount_value = wc_format_decimal( floatval( $data['discount'] ), 2 );
+                $discount_value = rtrim( rtrim( $discount_value, '0' ), '.' );
+
+                $item->add_meta_data(
+                    __( 'Subscription Savings', 'woo-special-product-offer' ),
+                    sprintf( /* translators: %s: discount percentage. */ __( '%s%% discount', 'woo-special-product-offer' ), $discount_value ),
+                    true
+                );
+            }
+        }
+    }
+}

--- a/wp-content/plugins/woo-special-product-offer/includes/class-wspo-plugin.php
+++ b/wp-content/plugins/woo-special-product-offer/includes/class-wspo-plugin.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Main plugin bootstrapper.
+ *
+ * @package Woo_Special_Product_Offer
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WSPO_Plugin' ) ) {
+
+    /**
+     * Primary plugin controller.
+     */
+    class WSPO_Plugin {
+
+        /**
+         * Singleton instance.
+         *
+         * @var WSPO_Plugin|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Retrieve the plugin instance.
+         *
+         * @return WSPO_Plugin
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Register required hooks.
+         */
+        protected function __construct() {
+            $this->load_dependencies();
+            $this->init_hooks();
+        }
+
+        /**
+         * Load supporting class files.
+         */
+        protected function load_dependencies() {
+            require_once WSPO_PLUGIN_DIR . 'includes/class-wspo-frontend.php';
+
+            if ( is_admin() ) {
+                require_once WSPO_PLUGIN_DIR . 'includes/class-wspo-settings.php';
+            }
+        }
+
+        /**
+         * Initialise WordPress hooks.
+         */
+        protected function init_hooks() {
+            add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+
+            if ( is_admin() ) {
+                WSPO_Settings::instance();
+            }
+
+            WSPO_Frontend::instance();
+        }
+
+        /**
+         * Handle plugin activation.
+         */
+        public static function activate() {
+            $defaults = self::get_default_settings();
+            $stored   = get_option( 'wspo_settings', array() );
+
+            if ( ! is_array( $stored ) || empty( $stored ) ) {
+                update_option( 'wspo_settings', $defaults );
+                return;
+            }
+
+            $sanitized               = wp_parse_args( $stored, $defaults );
+            $sanitized['frequencies'] = self::sanitize_frequencies( $sanitized['frequencies'] );
+
+            update_option( 'wspo_settings', $sanitized );
+        }
+
+        /**
+         * Handle plugin deactivation.
+         */
+        public static function deactivate() {
+            // No deactivation tasks required.
+        }
+
+        /**
+         * Load the plugin text domain for translations.
+         */
+        public function load_textdomain() {
+            load_plugin_textdomain( 'woo-special-product-offer', false, dirname( plugin_basename( WSPO_PLUGIN_FILE ) ) . '/languages' );
+        }
+
+        /**
+         * Retrieve plugin defaults.
+         *
+         * @return array
+         */
+        public static function get_default_settings() {
+            return array(
+                'enable_subscription'   => 1,
+                'subscription_discount' => 10,
+                'frequencies'           => array(
+                    'Every Week',
+                    'Every Month',
+                ),
+            );
+        }
+
+        /**
+         * Fetch plugin settings merged with defaults.
+         *
+         * @return array
+         */
+        public static function get_settings() {
+            $defaults = self::get_default_settings();
+            $stored   = get_option( 'wspo_settings', array() );
+
+            if ( ! is_array( $stored ) ) {
+                $stored = array();
+            }
+
+            $settings = wp_parse_args( $stored, $defaults );
+
+            $settings['enable_subscription']   = empty( $settings['enable_subscription'] ) ? 0 : 1;
+            $settings['subscription_discount'] = isset( $settings['subscription_discount'] ) ? floatval( $settings['subscription_discount'] ) : 0;
+            $settings['frequencies']           = self::sanitize_frequencies( $settings['frequencies'] );
+
+            return $settings;
+        }
+
+        /**
+         * Sanitize frequency values from settings.
+         *
+         * @param mixed $frequencies Frequency settings value.
+         * @return array
+         */
+        public static function sanitize_frequencies( $frequencies ) {
+            if ( is_string( $frequencies ) ) {
+                $frequencies = preg_split( '/\r?\n/', $frequencies );
+            }
+
+            if ( ! is_array( $frequencies ) ) {
+                $frequencies = array();
+            }
+
+            $sanitized = array();
+
+            foreach ( $frequencies as $frequency ) {
+                if ( is_array( $frequency ) && isset( $frequency['label'] ) ) {
+                    $frequency = $frequency['label'];
+                }
+
+                $label = sanitize_text_field( wp_unslash( $frequency ) );
+
+                if ( '' === $label ) {
+                    continue;
+                }
+
+                $sanitized[] = $label;
+            }
+
+            return $sanitized;
+        }
+
+        /**
+         * Produce the configured frequency options with machine-safe keys.
+         *
+         * @return array
+         */
+        public static function get_frequency_options() {
+            $settings = self::get_settings();
+            $options  = array();
+
+            foreach ( $settings['frequencies'] as $label ) {
+                $value = sanitize_title( $label );
+
+                if ( '' === $value ) {
+                    $value = substr( md5( $label ), 0, 8 );
+                }
+
+                $options[ $value ] = $label;
+            }
+
+            return $options;
+        }
+
+        /**
+         * Load a template file within the plugin.
+         *
+         * @param string $template Template filename.
+         * @param array  $args     Variables to expose in the template scope.
+         */
+        public static function get_template( $template, $args = array() ) {
+            $template_file = trailingslashit( WSPO_PLUGIN_DIR . 'templates' ) . $template;
+
+            if ( ! file_exists( $template_file ) ) {
+                return;
+            }
+
+            if ( ! empty( $args ) && is_array( $args ) ) {
+                extract( $args ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
+            }
+
+            include $template_file;
+        }
+    }
+}

--- a/wp-content/plugins/woo-special-product-offer/includes/class-wspo-settings.php
+++ b/wp-content/plugins/woo-special-product-offer/includes/class-wspo-settings.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Admin settings for Woo Special Product Offer.
+ *
+ * @package Woo_Special_Product_Offer
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WSPO_Settings' ) ) {
+
+    /**
+     * Registers settings and admin UI.
+     */
+    class WSPO_Settings {
+
+        /**
+         * Singleton instance.
+         *
+         * @var WSPO_Settings|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Retrieve the settings instance.
+         *
+         * @return WSPO_Settings
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Hook registration.
+         */
+        protected function __construct() {
+            add_action( 'admin_menu', array( $this, 'register_menu' ) );
+            add_action( 'admin_init', array( $this, 'register_settings' ) );
+        }
+
+        /**
+         * Add the plugin menu item under WooCommerce.
+         */
+        public function register_menu() {
+            add_submenu_page(
+                'woocommerce',
+                __( 'Special Product Offer', 'woo-special-product-offer' ),
+                __( 'Special Offer', 'woo-special-product-offer' ),
+                'manage_woocommerce',
+                'wspo-settings',
+                array( $this, 'render_settings_page' )
+            );
+        }
+
+        /**
+         * Register plugin settings and fields.
+         */
+        public function register_settings() {
+            register_setting( 'wspo_settings_group', 'wspo_settings', array( $this, 'sanitize_settings' ) );
+
+            add_settings_section(
+                'wspo_general_section',
+                __( 'Purchase Options', 'woo-special-product-offer' ),
+                array( $this, 'render_settings_description' ),
+                'wspo-settings'
+            );
+
+            add_settings_field(
+                'wspo_enable_subscription',
+                __( 'Enable subscription offers', 'woo-special-product-offer' ),
+                array( $this, 'render_enable_subscription_field' ),
+                'wspo-settings',
+                'wspo_general_section'
+            );
+
+            add_settings_field(
+                'wspo_subscription_discount',
+                __( 'Subscription discount (%)', 'woo-special-product-offer' ),
+                array( $this, 'render_subscription_discount_field' ),
+                'wspo-settings',
+                'wspo_general_section'
+            );
+
+            add_settings_field(
+                'wspo_frequencies',
+                __( 'Subscription frequencies', 'woo-special-product-offer' ),
+                array( $this, 'render_frequencies_field' ),
+                'wspo-settings',
+                'wspo_general_section'
+            );
+        }
+
+        /**
+         * Sanitize settings prior to save.
+         *
+         * @param array $input Raw settings.
+         * @return array
+         */
+        public function sanitize_settings( $input ) {
+            $defaults = WSPO_Plugin::get_default_settings();
+            $output   = wp_parse_args( is_array( $input ) ? $input : array(), $defaults );
+
+            $output['enable_subscription'] = empty( $input['enable_subscription'] ) ? 0 : 1;
+
+            $discount = isset( $input['subscription_discount'] ) ? floatval( $input['subscription_discount'] ) : $defaults['subscription_discount'];
+            $discount = max( 0, min( 100, $discount ) );
+            $output['subscription_discount'] = $discount;
+
+            $frequencies               = isset( $input['frequencies'] ) ? wp_unslash( $input['frequencies'] ) : array();
+            $output['frequencies']     = WSPO_Plugin::sanitize_frequencies( $frequencies );
+
+            return $output;
+        }
+
+        /**
+         * Section description callback.
+         */
+        public function render_settings_description() {
+            echo '<p>' . esc_html__( 'Configure how the Purchase Options panel behaves on product pages.', 'woo-special-product-offer' ) . '</p>';
+        }
+
+        /**
+         * Render enable subscription checkbox.
+         */
+        public function render_enable_subscription_field() {
+            $settings = WSPO_Plugin::get_settings();
+            ?>
+            <label for="wspo_enable_subscription">
+                <input type="checkbox" name="wspo_settings[enable_subscription]" id="wspo_enable_subscription" value="1" <?php checked( $settings['enable_subscription'], 1 ); ?> />
+                <?php esc_html_e( 'Allow customers to select a subscription and receive discounted pricing.', 'woo-special-product-offer' ); ?>
+            </label>
+            <?php
+        }
+
+        /**
+         * Render subscription discount field.
+         */
+        public function render_subscription_discount_field() {
+            $settings = WSPO_Plugin::get_settings();
+            ?>
+            <input type="number" min="0" max="100" step="0.1" name="wspo_settings[subscription_discount]" id="wspo_subscription_discount" value="<?php echo esc_attr( $settings['subscription_discount'] ); ?>" class="regular-text" />
+            <p class="description"><?php esc_html_e( 'Percentage discount to apply when a shopper selects a subscription.', 'woo-special-product-offer' ); ?></p>
+            <?php
+        }
+
+        /**
+         * Render frequencies textarea.
+         */
+        public function render_frequencies_field() {
+            $settings        = WSPO_Plugin::get_settings();
+            $frequencies     = isset( $settings['frequencies'] ) ? (array) $settings['frequencies'] : array();
+            $frequencies_txt = implode( "\n", $frequencies );
+            ?>
+            <textarea name="wspo_settings[frequencies]" id="wspo_frequencies" rows="5" cols="50" class="large-text code"><?php echo esc_textarea( $frequencies_txt ); ?></textarea>
+            <p class="description"><?php esc_html_e( 'Enter one frequency label per line (e.g. "Every Week"). These values will appear in the product dropdown.', 'woo-special-product-offer' ); ?></p>
+            <?php
+        }
+
+        /**
+         * Render the full settings page.
+         */
+        public function render_settings_page() {
+            if ( ! current_user_can( 'manage_woocommerce' ) ) {
+                return;
+            }
+            ?>
+            <div class="wrap ws-special-offer-settings">
+                <h1><?php esc_html_e( 'Woo Special Product Offer', 'woo-special-product-offer' ); ?></h1>
+                <p class="description"><?php esc_html_e( 'Create tailored purchase journeys with lightweight controls that match your brand.', 'woo-special-product-offer' ); ?></p>
+                <?php settings_errors( 'wspo_settings' ); ?>
+                <form action="options.php" method="post">
+                    <?php
+                    settings_fields( 'wspo_settings_group' );
+                    do_settings_sections( 'wspo-settings' );
+                    submit_button( __( 'Save changes', 'woo-special-product-offer' ) );
+                    ?>
+                </form>
+            </div>
+            <?php
+        }
+    }
+}

--- a/wp-content/plugins/woo-special-product-offer/templates/purchase-options.php
+++ b/wp-content/plugins/woo-special-product-offer/templates/purchase-options.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Purchase options template.
+ *
+ * @package Woo_Special_Product_Offer
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$discount          = isset( $settings['subscription_discount'] ) ? floatval( $settings['subscription_discount'] ) : 0;
+$current_type      = isset( $_POST['wspo_purchase_type'] ) ? sanitize_key( wp_unslash( $_POST['wspo_purchase_type'] ) ) : 'one_time';
+$current_frequency = isset( $_POST['wspo_plan_frequency'] ) ? sanitize_key( wp_unslash( $_POST['wspo_plan_frequency'] ) ) : '';
+
+if ( ! in_array( $current_type, array( 'one_time', 'subscription' ), true ) ) {
+    $current_type = 'one_time';
+}
+
+if ( 'subscription' !== $current_type ) {
+    $current_frequency = '';
+}
+
+$frequency_keys = array_keys( (array) $frequencies );
+if ( 'subscription' === $current_type && ( empty( $current_frequency ) || ! array_key_exists( $current_frequency, $frequencies ) ) ) {
+    $current_frequency = reset( $frequency_keys );
+}
+
+$heading = apply_filters( 'wspo_purchase_options_heading', __( 'Purchase Options', 'woo-special-product-offer' ) );
+$helper  = apply_filters( 'wspo_purchase_options_helper_text', __( 'Choose how you would like to buy this product.', 'woo-special-product-offer' ) );
+?>
+<div class="wspo-purchase-options" data-discount="<?php echo esc_attr( $discount ); ?>">
+    <div class="wspo-header">
+        <h3 class="wspo-title"><?php echo esc_html( $heading ); ?></h3>
+        <p class="wspo-helper"><?php echo esc_html( $helper ); ?></p>
+    </div>
+
+    <p class="wspo-price-note" aria-live="polite"></p>
+
+    <div class="wspo-option">
+        <label class="wspo-option-card">
+            <input type="radio" name="wspo_purchase_type" value="one_time" <?php checked( 'one_time', $current_type ); ?> />
+            <span class="wspo-option-content">
+                <span class="wspo-option-title"><?php esc_html_e( 'One-time purchase', 'woo-special-product-offer' ); ?></span>
+                <span class="wspo-option-description"><?php esc_html_e( 'Pay the standard price today.', 'woo-special-product-offer' ); ?></span>
+            </span>
+        </label>
+    </div>
+
+    <?php if ( ! empty( $has_subscribe ) && ! empty( $frequencies ) ) : ?>
+        <div class="wspo-option">
+            <label class="wspo-option-card">
+                <input type="radio" name="wspo_purchase_type" value="subscription" <?php checked( 'subscription', $current_type ); ?> />
+                <span class="wspo-option-content">
+                    <span class="wspo-option-title">
+                        <?php esc_html_e( 'Subscribe & Save', 'woo-special-product-offer' ); ?>
+                        <?php if ( $discount > 0 ) : ?>
+                            <span class="wspo-badge"><?php printf( esc_html__( 'Save %s%%', 'woo-special-product-offer' ), esc_html( rtrim( rtrim( wc_format_decimal( $discount, 2 ), '0' ), '.' ) ) ); ?></span>
+                        <?php endif; ?>
+                    </span>
+                    <span class="wspo-option-description"><?php esc_html_e( 'Auto-deliver on your schedule and unlock exclusive savings.', 'woo-special-product-offer' ); ?></span>
+                </span>
+            </label>
+
+            <div class="wspo-frequency <?php echo 'subscription' === $current_type ? '' : 'wspo-hidden'; ?>">
+                <label for="wspo_plan_frequency"><?php esc_html_e( 'Delivery frequency', 'woo-special-product-offer' ); ?></label>
+                <select name="wspo_plan_frequency" id="wspo_plan_frequency">
+                    <?php foreach ( $frequencies as $value => $label ) : ?>
+                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $current_frequency ); ?>><?php echo esc_html( $label ); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <?php wp_nonce_field( 'wspo_purchase_options', 'wspo_nonce' ); ?>
+</div>

--- a/wp-content/plugins/woo-special-product-offer/woo-special-product-offer.php
+++ b/wp-content/plugins/woo-special-product-offer/woo-special-product-offer.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name:       Woo Special Product Offer
+ * Plugin URI:        https://binawebpro.com/woo-special-product-offer
+ * Description:       Adds modern purchase option controls to WooCommerce products so customers can choose between one-time purchases and subscriptions.
+ * Version:           1.0.0
+ * Author:            [Wan Mohd Aiman Binawebpro.com]
+ * Author URI:        https://binawebpro.com
+ * Text Domain:       woo-special-product-offer
+ * Domain Path:       /languages
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'WSPO_VERSION', '1.0.0' );
+define( 'WSPO_PLUGIN_FILE', __FILE__ );
+define( 'WSPO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'WSPO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+require_once WSPO_PLUGIN_DIR . 'includes/class-wspo-plugin.php';
+
+register_activation_hook( WSPO_PLUGIN_FILE, array( 'WSPO_Plugin', 'activate' ) );
+register_deactivation_hook( WSPO_PLUGIN_FILE, array( 'WSPO_Plugin', 'deactivate' ) );
+
+WSPO_Plugin::instance();


### PR DESCRIPTION
## Summary
- add the Woo Special Product Offer plugin bootstrap with activation defaults and shared helpers
- implement the frontend purchase options template, cart/order persistence, and supporting assets
- provide WooCommerce admin settings plus documentation covering installation and configuration

## Testing
- php -l wp-content/plugins/woo-special-product-offer/woo-special-product-offer.php
- php -l wp-content/plugins/woo-special-product-offer/includes/class-wspo-plugin.php
- php -l wp-content/plugins/woo-special-product-offer/includes/class-wspo-frontend.php
- php -l wp-content/plugins/woo-special-product-offer/includes/class-wspo-settings.php
- php -l wp-content/plugins/woo-special-product-offer/templates/purchase-options.php


------
https://chatgpt.com/codex/tasks/task_e_68d2d330d434833092cc1ffe65a0c03b