### PR TITLE
Handle object results in subscriber list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Woo Special Product Offer
 
-**Version:** 1.2.1  \
+**Version:** 1.2.2  \
 **Author:** [Wan Mohd Aiman Binawebpro.com]
 
 Woo Special Product Offer is a lightweight WordPress plugin that enriches WooCommerce product pages with a modern “Purchase Options” experience. Customers can easily toggle between one-time purchases and subscriptions, choose their preferred delivery frequency, and instantly understand how much they will save. Behind the scenes the plugin keeps the cart, checkout, and resulting orders in sync with each shopper’s selection.

--- a/wp-content/plugins/woo-special-product-offer/includes/class-wspo-subscribers.php
+++ b/wp-content/plugins/woo-special-product-offer/includes/class-wspo-subscribers.php
@@ -513,6 +513,20 @@ if ( ! class_exists( 'WSPO_Subscriber_List_Table' ) ) {
             $order_ids   = array();
             $total_items = 0;
 
+            if ( $results instanceof stdClass ) {
+                $orders      = isset( $results->orders ) ? (array) $results->orders : array();
+                $total_items = isset( $results->total ) ? (int) $results->total : count( $orders );
+
+                $results = array(
+                    'orders' => $orders,
+                    'total'  => $total_items,
+                );
+            } elseif ( is_object( $results ) ) {
+                $results            = (array) $results;
+                $results['orders']  = isset( $results['orders'] ) ? (array) $results['orders'] : array();
+                $results['total']   = isset( $results['total'] ) ? (int) $results['total'] : count( $results['orders'] );
+            }
+
             if ( isset( $results['orders'] ) && is_array( $results['orders'] ) ) {
                 $order_ids   = $results['orders'];
                 $total_items = isset( $results['total'] ) ? (int) $results['total'] : count( $order_ids );

--- a/wp-content/plugins/woo-special-product-offer/woo-special-product-offer.php
+++ b/wp-content/plugins/woo-special-product-offer/woo-special-product-offer.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Woo Special Product Offer
  * Plugin URI:        https://binawebpro.com/woo-special-product-offer
  * Description:       Adds modern purchase option controls to WooCommerce products so customers can choose between one-time purchases and subscriptions.
- * Version:           1.2.1
+ * Version:           1.2.2
  * Author:            [Wan Mohd Aiman Binawebpro.com]
  * Author URI:        https://binawebpro.com
  * Text Domain:       woo-special-product-offer
@@ -12,7 +12,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WSPO_VERSION', '1.2.1' );
+define( 'WSPO_VERSION', '1.2.2' );
 define( 'WSPO_PLUGIN_FILE', __FILE__ );
 define( 'WSPO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WSPO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- normalize subscriber query results when the datastore returns objects
- default orders and totals for object responses so the list table pagination stays accurate
- bump the plugin version to 1.2.2 to reflect the change

## Testing
- php -l wp-content/plugins/woo-special-product-offer/includes/class-wspo-subscribers.php
- php -l wp-content/plugins/woo-special-product-offer/woo-special-product-offer.php

------
https://chatgpt.com/codex/tasks/task_e_68d39822979c8330a1d8c1150862b85c