### PR TITLE
Add phone filter and WhatsApp shortcut to subscriber report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Woo Special Product Offer
 
-**Version:** 1.2.2  \
+**Version:** 1.2.3  \
 **Author:** [Wan Mohd Aiman Binawebpro.com]
 
 Woo Special Product Offer is a lightweight WordPress plugin that enriches WooCommerce product pages with a modern “Purchase Options” experience. Customers can easily toggle between one-time purchases and subscriptions, choose their preferred delivery frequency, and instantly understand how much they will save. Behind the scenes the plugin keeps the cart, checkout, and resulting orders in sync with each shopper’s selection.

--- a/wp-content/plugins/woo-special-product-offer/assets/css/wspo-subscribers.css
+++ b/wp-content/plugins/woo-special-product-offer/assets/css/wspo-subscribers.css
@@ -7,3 +7,26 @@
 .ws-special-offer-subscribers .wspo-subscribers-actions form {
     margin: 0;
 }
+
+.ws-special-offer-subscribers .wspo-whatsapp-button {
+    background-color: #25d366;
+    border-color: #25d366;
+    color: #ffffff;
+    text-decoration: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.ws-special-offer-subscribers .wspo-whatsapp-button:hover,
+.ws-special-offer-subscribers .wspo-whatsapp-button:focus {
+    background-color: #1ebc57;
+    border-color: #1ebc57;
+    color: #ffffff;
+}
+
+.ws-special-offer-subscribers .wspo-whatsapp-button:focus {
+    box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px rgba(37, 211, 102, 0.45);
+}
+
+.ws-special-offer-subscribers .wspo-whatsapp-unavailable {
+    color: #6c7781;
+}

--- a/wp-content/plugins/woo-special-product-offer/woo-special-product-offer.php
+++ b/wp-content/plugins/woo-special-product-offer/woo-special-product-offer.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Woo Special Product Offer
  * Plugin URI:        https://binawebpro.com/woo-special-product-offer
  * Description:       Adds modern purchase option controls to WooCommerce products so customers can choose between one-time purchases and subscriptions.
- * Version:           1.2.2
+ * Version:           1.2.3
  * Author:            [Wan Mohd Aiman Binawebpro.com]
  * Author URI:        https://binawebpro.com
  * Text Domain:       woo-special-product-offer
@@ -12,7 +12,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WSPO_VERSION', '1.2.2' );
+define( 'WSPO_VERSION', '1.2.3' );
 define( 'WSPO_PLUGIN_FILE', __FILE__ );
 define( 'WSPO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WSPO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add UI and query handling to filter subscriber list by presence of subscription phone numbers
- provide a WhatsApp action column with sanitized wa.me link and filter-respecting export logic
- style the new button and bump plugin version metadata to 1.2.3

## Testing
- php -l wp-content/plugins/woo-special-product-offer/includes/class-wspo-subscribers.php
- php -l wp-content/plugins/woo-special-product-offer/woo-special-product-offer.php

------
https://chatgpt.com/codex/tasks/task_e_68d3a21d44388330959725c1e0c25266